### PR TITLE
Fix CVE-2026-32597 by upgrading PyJWT to 2.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ idna==2.8
 itsdangerous==1.1.0
 Jinja2==2.10.3
 MarkupSafe==1.1.1
-PyJWT==1.7.1
+PyJWT==2.12.0
 pytz==2019.3
 requests==2.22.0
 six==1.13.0


### PR DESCRIPTION
This PR upgrades PyJWT to version 2.12.0 in `requirements.txt` to address a known vulnerability (CVE-2026-32597) where PyJWT does not properly validate the `crit` header extension, potentially leading to security issues.

No code modifications were required as there were no direct usages of `PyJWT` or `jwt` found in the project's source code files. Strict version pinning `==` is maintained per project conventions.

---
*PR created automatically by Jules for task [3268853589000527410](https://jules.google.com/task/3268853589000527410) started by @Zebfred*